### PR TITLE
Remove usage of GeoModelAdmin

### DIFF
--- a/djangostreetmap/admin.py
+++ b/djangostreetmap/admin.py
@@ -1,8 +1,11 @@
-from django.contrib.gis import admin
+from django.contrib import admin
+from django.contrib.gis.forms import OSMWidget
 
 from djangostreetmap import models
 
 
 @admin.register(models.SimplifiedLandPolygon)
-class SimplifiedLandPolygonAdmin(admin.GeoModelAdmin):  # type: ignore
-    pass
+class SimplifiedLandPolygonAdmin(admin.ModelAdmin):  # type: ignore
+    formfield_overrides = {
+        models.MultiPolygonField: {"widget": OSMWidget},
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ exclude = '''
 
 [tool.poetry]
 name = "djangostreetmap"
-version = "0.2.6"
+version = "0.2.8"
 description = "Deliver OpenstreetMap data in GeoJSON and MVT tile formats"
 authors = ["Joshua Brooks <josh.vdbroek@gmail.com>"]
 license = "LGPL-3.0-or-later"


### PR DESCRIPTION
Removed in Django 5, see https://code.djangoproject.com/ticket/27674

They recommend defining the geo widget explicitly, which I do:

![Screenshot 2024-03-07 at 11 17 44](https://github.com/catalpainternational/djangostreetmap/assets/5139869/29bca898-1dd1-4d32-ba44-4c56e615d48b)
