### PR TITLE
maplibre: track style-spec v25.x (0.3.3)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -60,20 +60,23 @@ Not re-exported at package level (import from `djangostreetmap.views`).
 from maplibre import (
     Root, Layer, Layout, Paint, BackgroundPaint,
     Vector, Raster, RasterDem, GeoJson, Image, Video, Source, AnySource,
-    Light, Anchor, Sprite, Transition,
+    Light, Anchor, Sky, Terrain, Projection, Sprite, Transition,
 )
 ```
 
-Pydantic v2 models for the MapLibre / Mapbox style spec. Every field carries a
-`description=...` matching the upstream spec.
+Pydantic v2 models tracking the current MapLibre style spec (v25.x). Every
+field carries a `description=...` matching the upstream spec.
 
 | Name                                        | Purpose                                                       |
 | ------------------------------------------- | ------------------------------------------------------------- |
-| `Root`                                      | Top-level style: `version`, `sources`, `layers`, ...           |
-| `Layer`, `Layout`, `Paint`, `BackgroundPaint` | Layer + rendering rules.                                     |
-| `Vector`, `Raster`, `RasterDem`, `GeoJson`, `Image`, `Video` | Source types, discriminated on `type`.  |
+| `Root`                                      | Top-level style: `version`, `sources`, `layers`, plus optional `sky`, `terrain`, `projection`, `transition`, `state`, `roll`, `centerAltitude`. |
+| `Layer`, `Layout`, `Paint`, `BackgroundPaint` | Layer + rendering rules. Layer `type` includes `color-relief` (v24.x+). |
+| `Vector`, `Raster`, `RasterDem`, `GeoJson`, `Image`, `Video` | Source types, discriminated on `type`. `Vector` supports the `encoding` field (mvt/mlt); `RasterDem` supports custom encoding factors (`redFactor`/`greenFactor`/`blueFactor`/`baseShift`). |
 | `Source`, `AnySource`                       | Base + tagged union of all source types.                       |
 | `Light`, `Anchor`                           | 3D lighting spec.                                              |
+| `Sky`                                       | Sky, atmosphere, horizon, and fog configuration.               |
+| `Terrain`                                   | 3D terrain from a `raster-dem` source (`source`, `exaggeration`). |
+| `Projection`                                | Map projection (`mercator`, `vertical-perspective`, or an expression). |
 | `Sprite`, `Transition`                      | Sprite atlas + transition timing.                              |
 
 ### Parsing / dumping

--- a/maplibre/__init__.py
+++ b/maplibre/__init__.py
@@ -1,7 +1,9 @@
-"""maplibre: pydantic models for the MapLibre / Mapbox style spec.
+"""maplibre: pydantic models for the MapLibre style spec.
 
-Instantiate :class:`~maplibre.basemodel.Root` (the top-level style) or any of
-the layer / source / light models directly, or parse an existing style JSON::
+Tracks the current MapLibre style spec (v25.x). Instantiate
+:class:`~maplibre.basemodel.Root` (the top-level style) or any of the layer /
+source / light / sky / terrain / projection models directly, or parse an
+existing style JSON::
 
     from maplibre import Root
     style = Root.model_validate_json(open("style.json").read())
@@ -10,8 +12,11 @@ the layer / source / light models directly, or parse an existing style JSON::
 from maplibre.basemodel import Root
 from maplibre.layer import BackgroundPaint, Layer, Layout, Paint
 from maplibre.light import Anchor, Light
+from maplibre.projection import Projection
+from maplibre.sky import Sky
 from maplibre.sources import AnySource, GeoJson, Image, Raster, RasterDem, Source, Vector, Video
 from maplibre.sprite import Sprite
+from maplibre.terrain import Terrain
 from maplibre.transition import Transition
 
 __all__ = [
@@ -24,11 +29,14 @@ __all__ = [
     "Layout",
     "Light",
     "Paint",
+    "Projection",
     "Raster",
     "RasterDem",
     "Root",
+    "Sky",
     "Source",
     "Sprite",
+    "Terrain",
     "Transition",
     "Vector",
     "Video",

--- a/maplibre/basemodel.py
+++ b/maplibre/basemodel.py
@@ -1,59 +1,84 @@
+"""MapLibre style-spec `Root` object.
+
+Mirrors https://maplibre.org/maplibre-style-spec/root/ .
+"""
+
 from typing import Any
 
-from pydantic import AnyUrl, BaseModel, Field, ValidationInfo, field_validator
+from pydantic import AnyUrl, BaseModel, ConfigDict, Field, ValidationInfo, field_validator
 
 from .layer import Layer
 from .light import Light
+from .projection import Projection
+from .sky import Sky
 from .sources import AnySource
+from .terrain import Terrain
+from .transition import Transition
 
 
 class Root(BaseModel):
-    id: str | None = None
-    bearing: int | float | None = Field(
+    """Top-level MapLibre style. `sources` and `layers` are the required fields."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    version: int = Field(8, description="Style specification version number (must be 8).")
+    name: str | None = Field(None, description="A human-readable name for the style.")
+    metadata: dict[str, Any] | None = Field(
         None,
-        description="""Default bearing, in degrees. The bearing is the compass direction that is "up"; for example, a bearing of 90° orients the map so that east is up. This value will be used only if the map has not been positioned by other means (e.g. map options or user interaction).""",
+        description="Arbitrary properties useful to track with the stylesheet; do not influence rendering. Properties should be prefixed to avoid collisions, like 'mapbox:'.",
     )
     center: tuple[float, float] | None = Field(
         None,
-        description="""Default map center in longitude and latitude. The style center will be used only if the map has not been positioned by other means (e.g. map options or user interaction).""",
+        description="Default map center in [longitude, latitude]. Used only if the map is not otherwise positioned.",
+    )
+    center_altitude: float | None = Field(
+        None,
+        alias="centerAltitude",
+        description="Default altitude of the map center in meters (v5.0.0+).",
+    )
+    zoom: float | None = Field(None, description="Default zoom level.")
+    bearing: int | float | None = Field(
+        None,
+        description="Default bearing in degrees. 90° puts east up. Used only if the map is not otherwise positioned.",
+    )
+    pitch: int | float | None = Field(
+        None,
+        description="Default pitch in degrees. 0 = looking straight down; higher values tilt toward the horizon.",
+    )
+    roll: int | float | None = Field(
+        None,
+        description="Default roll in degrees (v5.0.0+).",
+    )
+    light: Light | None = Field(None, description="The global light source.")
+    sky: Sky | None = Field(None, description="Sky, atmosphere, horizon, and fog configuration.")
+    projection: Projection | None = Field(None, description="Map projection.")
+    terrain: Terrain | None = Field(None, description="3D terrain configuration referencing a raster-dem source.")
+    sources: dict[str, AnySource] = Field(description="Data source specifications.")
+    sprite: AnyUrl | list[dict[str, Any]] | None = Field(
+        None,
+        description=(
+            "Sprite atlas: either a base URL (extensions .png/.json/@2x.png appended automatically) or an array of "
+            "sprite objects for multi-sprite support. Required if any layer uses a *-pattern or icon-image property."
+        ),
     )
     glyphs: AnyUrl | None = Field(
         None,
-        description="""A URL template for loading signed-distance-field glyph sets in PBF format. The URL must include {fontstack} and {range} tokens. This property is required if any layer uses the text-field layout property. The URL must be absolute, containing the scheme, authority and path components.""",
+        description="URL template for signed-distance-field glyph PBFs (must include {fontstack} and {range}).",
     )
-    light: Light | None = Field(None, description="""The global light source.""")
-    metadata: dict[str, Any] | None = Field(
+    transition: Transition | None = Field(
         None,
-        description="""Arbitrary properties useful to track with the stylesheet, but do not influence rendering. Properties should be prefixed to avoid collisions, like 'mapbox:'.""",
+        description="Global transition defaults for animated property changes.",
     )
-    name: str | None = Field(None, description="""A human-readable name for the style.""")
-    pitch: int | float | None = Field(
+    state: dict[str, Any] | None = Field(
         None,
-        description="""Default pitch, in degrees. Zero is perpendicular to the surface, for a look straight down at the map, while a greater value like 60 looks ahead towards the horizon. The style pitch will be used only if the map has not been positioned by other means (e.g. map options or user interaction).""",
+        description="Style state variables consumable by global-state expressions (v5.6.0+).",
     )
-    sources: dict[str, AnySource] = Field(description="""Data source specifications.""")
-    layers: list[Layer]
-    sprite: AnyUrl | None = Field(
-        None,
-        description="""A base URL for retrieving the sprite image and metadata. The extensions .png, .json and scale factor @2x.png will be automatically appended. This property is required if any layer uses the background-pattern, fill-pattern, line-pattern, fill-extrusion-pattern, or icon-image properties. The URL must be absolute, containing the scheme, authority and path components.""",
-    )
-    transition: str | None = Field(
-        None,
-        description="""A global transition definition to use as a default across properties, to be used for timing transitions between one value and the next when no property-specific transition is set. Collision-based symbol fading is controlled independently of the style's transition property.""",
-    )
-    version: int = Field(8, description="""Style specification version number.""")
-
-    zoom: float | None = Field(
-        None,
-        description="""Default zoom level. The style zoom will be used only if the map has not been positioned by other means (e.g. map options or user interaction).""",
-    )
+    layers: list[Layer] = Field(description="Ordered list of style layers (bottom-to-top).")
 
     @field_validator("layers")
     @classmethod
     def layer_source_is_in_sources(cls, layers: list[Layer], info: ValidationInfo):
-        """
-        Ensure that the reference exists in the `sources` map
-        """
+        """Ensure every non-background layer's `source` references a declared source."""
         sources: dict[str, AnySource] | None = info.data.get("sources")
         if sources is None:
             # sources failed to validate; skip cross-field check

--- a/maplibre/layer.py
+++ b/maplibre/layer.py
@@ -27,6 +27,7 @@ class TypeEnum(str, Enum):
     fillExtrusion = "fill-extrusion"
     raster = "raster"
     hillshade = "hillshade"
+    colorRelief = "color-relief"
     background = "background"
 
 
@@ -53,7 +54,7 @@ class Layer(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    type: Literal["fill", "line", "symbol", "circle", "heatmap", "fill-extrusion", "raster", "hillshade", "background"]
+    type: Literal["fill", "line", "symbol", "circle", "heatmap", "fill-extrusion", "raster", "hillshade", "color-relief", "background"]
     filter: Expression | None = Field(
         None,
         description="""A expression specifying conditions on source features. Only features that match the filter are displayed. Zoom expressions in filters are only evaluated at integer zoom levels. The feature-state expression is not supported in filter expressions.""",

--- a/maplibre/projection.py
+++ b/maplibre/projection.py
@@ -1,0 +1,19 @@
+"""MapLibre style-spec `Projection` object."""
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class Projection(BaseModel):
+    """The `projection` root-level object selects the map projection.
+
+    In the spec `type` is a "projectionDefinition" — commonly the string
+    ``"mercator"`` or ``"vertical-perspective"``, but also an expression (an
+    array) for zoom-dependent projection transitions. Modelled as
+    ``str | list`` to accept both forms.
+
+    See https://maplibre.org/maplibre-style-spec/projection/ .
+    """
+
+    type: str | list[Any] = Field("mercator", description="Projection definition: name string or expression.")

--- a/maplibre/sky.py
+++ b/maplibre/sky.py
@@ -1,0 +1,20 @@
+"""MapLibre style-spec `Sky` object (root-level sky/atmosphere/fog configuration)."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class Sky(BaseModel):
+    """The `sky` root-level object controls sky, atmosphere, horizon, and fog rendering.
+
+    See https://maplibre.org/maplibre-style-spec/sky/ .
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    sky_color: str | None = Field("#88C6FC", alias="sky-color", description="Base color for the sky.")
+    horizon_color: str | None = Field("#ffffff", alias="horizon-color", description="Base color at the horizon.")
+    fog_color: str | None = Field("#ffffff", alias="fog-color", description="Base color for fog; requires 3D terrain.")
+    fog_ground_blend: float | None = Field(0.5, alias="fog-ground-blend", description="Blend of fog over 3D terrain from map center to horizon.")
+    horizon_fog_blend: float | None = Field(0.8, alias="horizon-fog-blend", description="Blend factor between fog and horizon colors.")
+    sky_horizon_blend: float | None = Field(0.8, alias="sky-horizon-blend", description="Blend factor between sky and horizon colors.")
+    atmosphere_blend: float | None = Field(0.8, alias="atmosphere-blend", description="Atmosphere visibility; strongest with globe projection.")

--- a/maplibre/sources.py
+++ b/maplibre/sources.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Annotated, Literal
 
-from pydantic import AnyUrl, BaseModel, Field, HttpUrl
+from pydantic import AnyUrl, BaseModel, ConfigDict, Field, HttpUrl
 
 from djangostreetmap.annotations import GeoJsonFeature, GeoJsonFeatureCollection
 
@@ -30,11 +30,23 @@ class SchemeEnum(str, Enum):
 
 
 class EncodingEnum(str, Enum):
+    """Height-encoding scheme for `raster-dem` tiles."""
+
     terrarium = "terrarium"
     mapbox = "mapbox"
+    custom = "custom"
+
+
+class VectorEncodingEnum(str, Enum):
+    """Tile encoding for `vector` sources."""
+
+    mvt = "mvt"
+    mlt = "mlt"
 
 
 class Source(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     attribution: str | None = Field(None, description="Contains an attribution to be displayed when the map is shown to a user.")
     bounds: list[float] = Field(
         default_factory=lambda: [-180, -85.051129, 180, 85.051129],
@@ -74,6 +86,7 @@ class Vector(Source):
     )
     url: AnyUrl | None = Field(None, description="A URL to a TileJSON resource.")
     scheme: SchemeEnum = Field(SchemeEnum.xyz, description="Influences the y direction of the tile coordinates. The global-mercator (aka Spherical Mercator) profile is assumed.")
+    encoding: VectorEncodingEnum | None = Field(None, description="Tile encoding: 'mvt' (default) or 'mlt'.")
 
 
 class Raster(Source):
@@ -87,7 +100,11 @@ class RasterDem(Source):
     """
 
     type: Literal["raster-dem"] = "raster-dem"
-    encoding: EncodingEnum = Field(EncodingEnum.mapbox, description="The encoding used by this source. Mapbox Terrain RGB is used by default")
+    encoding: EncodingEnum = Field(EncodingEnum.mapbox, description="Height encoding: mapbox (default), terrarium, or custom.")
+    red_factor: float | None = Field(None, alias="redFactor", description="Custom encoding: multiplier for the red channel when computing height.")
+    green_factor: float | None = Field(None, alias="greenFactor", description="Custom encoding: multiplier for the green channel when computing height.")
+    blue_factor: float | None = Field(None, alias="blueFactor", description="Custom encoding: multiplier for the blue channel when computing height.")
+    base_shift: float | None = Field(None, alias="baseShift", description="Custom encoding: additive height offset in metres.")
     url: AnyUrl | None = Field(None, description="A URL to a TileJSON resource.")
 
 

--- a/maplibre/terrain.py
+++ b/maplibre/terrain.py
@@ -1,0 +1,13 @@
+"""MapLibre style-spec `Terrain` object (3D elevation from a raster-dem source)."""
+
+from pydantic import BaseModel, Field
+
+
+class Terrain(BaseModel):
+    """The `terrain` root-level object binds a raster-dem source to 3D elevation.
+
+    See https://maplibre.org/maplibre-style-spec/terrain/ .
+    """
+
+    source: str = Field(description="Name of a raster-dem source in `sources`.")
+    exaggeration: float = Field(1.0, ge=0.0, description="Terrain-height exaggeration factor.")

--- a/maplibre/test_roundtrip.py
+++ b/maplibre/test_roundtrip.py
@@ -8,7 +8,7 @@ import json
 from importlib.resources import files
 from unittest import TestCase
 
-from maplibre import Layer, Root
+from maplibre import Layer, Projection, RasterDem, Root, Sky, Terrain, Transition, Vector
 
 
 def _load(name: str) -> dict:
@@ -38,6 +38,65 @@ class GoldenFixtureRoundtripTests(TestCase):
             {layer["id"] for layer in redumped["layers"]},
             {layer["id"] for layer in original["layers"]},
         )
+
+
+class SpecFieldsTests(TestCase):
+    """The newer style-spec top-level fields are wired and typed correctly."""
+
+    def test_transition_is_typed_object(self):
+        # `transition` on Root must be the Transition object, not a string.
+        root = Root(
+            sources={},
+            layers=[Layer(id="bg", type="background")],
+            transition=Transition(duration=500, delay=100),
+        )
+        self.assertIsNotNone(root.transition)
+        self.assertEqual(root.transition.duration, 500)
+
+    def test_sky_terrain_projection_accepted(self):
+        root = Root(
+            sources={"dem": RasterDem(url="mapbox://mapbox.terrain-rgb")},
+            layers=[Layer(id="bg", type="background")],
+            sky=Sky(),
+            terrain=Terrain(source="dem", exaggeration=1.5),
+            projection=Projection(type="mercator"),
+        )
+        self.assertEqual(root.terrain.source, "dem")
+        self.assertEqual(root.projection.type, "mercator")
+        self.assertEqual(root.sky.sky_color, "#88C6FC")
+
+    def test_state_and_roll_and_center_altitude_accepted(self):
+        root = Root(
+            sources={},
+            layers=[Layer(id="bg", type="background")],
+            roll=15,
+            centerAltitude=1200,
+            state={"foo": 42},
+        )
+        self.assertEqual(root.roll, 15)
+        self.assertEqual(root.center_altitude, 1200)
+        self.assertEqual(root.state, {"foo": 42})
+
+    def test_color_relief_is_a_valid_layer_type(self):
+        layer = Layer(id="relief", type="color-relief", source="dem")
+        self.assertEqual(layer.type, "color-relief")
+
+    def test_vector_encoding_field(self):
+        v = Vector(tiles=["http://example.com/{z}/{x}/{y}.pbf"], encoding="mlt")
+        self.assertEqual(v.encoding.value, "mlt")
+
+    def test_raster_dem_custom_encoding_factors(self):
+        rd = RasterDem(
+            url="mapbox://foo",
+            encoding="custom",
+            redFactor=256.0,
+            greenFactor=1.0,
+            blueFactor=1 / 256.0,
+            baseShift=-10000.0,
+        )
+        self.assertEqual(rd.red_factor, 256.0)
+        self.assertAlmostEqual(rd.blue_factor, 1 / 256.0)
+        self.assertEqual(rd.base_shift, -10000.0)
 
 
 class BackgroundLayerValidatorTests(TestCase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "djangostreetmap"
-version = "0.3.2"
+version = "0.3.3"
 description = "Deliver OpenStreetMap data in GeoJSON and MVT tile formats"
 readme = "README.md"
 requires-python = ">=3.11,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -329,7 +329,7 @@ wheels = [
 
 [[package]]
 name = "djangostreetmap"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
Brings the \`maplibre/\` pydantic models up to the current MapLibre style spec (v25.0.1, released 2026-06-29).

## Summary of spec changes covered

**Root**:
- \`transition\` was \`str | None\` — this was a latent bug; the spec says it's a Transition **object**. Fixed to \`Transition | None\`.
- New fields: \`sky\`, \`terrain\`, \`projection\`, \`roll\`, \`centerAltitude\` (aliased), \`state\`.
- Dropped the non-spec \`id\` field (pydantic v2 silently ignores extra fields, so golden fixtures still parse).
- \`sprite\` accepts either a URL or a list (multi-sprite arrays).

**Layer**:
- Added \`color-relief\` to the \`type\` Literal (new elevation-based layer type).

**Vector source**:
- New optional \`encoding\` field (\`mvt\` / \`mlt\`).

**RasterDem source**:
- \`encoding\` gains \`custom\`.
- New \`redFactor\`/\`greenFactor\`/\`blueFactor\`/\`baseShift\` fields for custom RGB→height decoding.

**New modules**: \`maplibre/sky.py\`, \`maplibre/terrain.py\`, \`maplibre/projection.py\`.

**Re-exports**: \`Sky\`, \`Terrain\`, \`Projection\` from \`maplibre/__init__.py\`.

## Test plan

- [x] \`uv run ruff check .\` — clean
- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run mypy djangostreetmap maplibre\` — success
- [x] \`uv run pytest --cov --cov-fail-under=60\` — **48 passed, 94.27% coverage** (6 new tests: transition-is-object, sky/terrain/projection accepted, state+roll+centerAltitude accepted, color-relief layer, vector encoding, raster-dem custom factors).
- [x] Golden-fixture tests still pass (\`style.json\`, \`osm_liberty.json\`).
- [x] \`uv build && twine check dist/*\` — PASSED
- [ ] CI green
- [ ] After merge: tag \`0.3.3\`, confirm release workflow publishes.